### PR TITLE
在 README 中添加 AUR 安装方式介绍

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ ZonyLrcToolX 4 是一个基于 CEF 的跨平台歌词下载工具，**QQ 群:337
 
 如果你要获取最新版本，请访问 **[Release](https://github.com/real-zony/ZonyLrcToolsX/releases)** 页面进行下载。
 
+## Arch Linux 用户仓库
+
+本软件已打包到 [AUR](https://aur.archlinux.org/packages/zonylrctoolsx-bin)。Arch Linux 及其衍生发行版用户可用如下命令安装：
+
+```bash
+# yay 或其他 AUR Helper
+yay -S zonylrctoolsx-bin
+
+ZonyLrcTools.Cli --help
+```
+
 # 用法
 
 软件的具体使用方法已经迁移到了全新的文档站点，请跳转到 [https://docs.myzony.com](https://docs.myzony.com)，里面包含完整的说明文档。


### PR DESCRIPTION
维护者：

非常感谢你的软件！帮助我节省了很多手动匹配歌词的时间。

我将本软件打包到了 [AUR](https://aur.archlinux.org/packages/zonylrctoolsx-bin)（Arch User Repository）中，这样 Arch Linux 用户可以直接用如下一行命令安装：

```
yay -S zonylrctoolsx-bin
```

该过程中将直接从本仓库的 Releases 下载软件，并安装到合适位置。

如果您要让 Windows（或 macOS）用户体验一样的便利，我也可以帮助打包 winget 和 homebrew 的版本。