### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Detailed usage instructions have been moved to a new documentation site. Please 
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.com/#real-zony/ZonyLrcToolsX&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.dera.page/#real-zony/ZonyLrcToolsX&Timeline)

--- a/docs/en_US.md
+++ b/docs/en_US.md
@@ -36,4 +36,4 @@ Detailed usage instructions have been moved to a new documentation site. Please 
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.com/#real-zony/ZonyLrcToolsX&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.dera.page/#real-zony/ZonyLrcToolsX&Timeline)

--- a/docs/zh_CN.md
+++ b/docs/zh_CN.md
@@ -37,4 +37,4 @@ ZonyLrcTools.Cli --help
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.com/#real-zony/ZonyLrcToolsX&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=real-zony/ZonyLrcToolsX&type=Timeline)](https://star-history.dera.page/#real-zony/ZonyLrcToolsX&Timeline)


### PR DESCRIPTION
The star history chart in the README and localized docs is currently broken because the underlying GitHub stargazer API data source is restricted. This changes the chart image and its link to use the new star-history domain, which relies on a different data source that requires no API token, so the chart renders correctly again.